### PR TITLE
travis: drop unsupported PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
   - 7.0


### PR DESCRIPTION
As already stated in composer.json